### PR TITLE
popping stmt_location

### DIFF
--- a/pglast/__init__.py
+++ b/pglast/__init__.py
@@ -75,6 +75,7 @@ def _remove_stmt_len_and_location(parse_tree):
         for k, v in parse_tree.items():
             if k == 'RawStmt':
                 v.pop('stmt_len', None)
+                v.pop('stmt_location', None)
             if v and isinstance(v, (dict, list)):
                 _remove_stmt_len_and_location(v)
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -73,8 +73,9 @@ def test_pg_version():
 
 
 def test_multiple_statement_safety_belt():
-    sql1 = 'select a from x; select b from y'
-    sql2 = 'select a from x;\n\nselect b from y'
-    assert _remove_stmt_len_and_location(parse_sql(sql1)) == _remove_stmt_len_and_location(parse_sql(sql2))
-    assert _remove_stmt_len_and_location(parse_sql(sql1)[0]) == _remove_stmt_len_and_location(parse_sql(sql2)[0])
-    assert _remove_stmt_len_and_location(parse_sql(sql1)[1]) == _remove_stmt_len_and_location(parse_sql(sql2)[1])
+    sql1 = parse_sql('select a from x; select b from y')
+    sql2 = parse_sql('select a from x;\n\nselect b from y')
+    assert sql1 != sql2
+    _remove_stmt_len_and_location(sql1)
+    _remove_stmt_len_and_location(sql2)
+    assert sql1 == sql2

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -8,7 +8,13 @@
 
 import pytest
 
-from pglast import Error, get_postgresql_version, parse_plpgsql, parse_sql
+from pglast import (
+    Error,
+    get_postgresql_version,
+    parse_plpgsql,
+    parse_sql,
+    _remove_stmt_len_and_location
+)
 
 
 def test_basic():
@@ -64,3 +70,11 @@ def test_pg_version():
     pg_version = get_postgresql_version()
     assert isinstance(pg_version, tuple)
     assert len(pg_version) == 3
+
+
+def test_multiple_statement_safety_belt():
+    sql1 = 'select a from x; select b from y'
+    sql2 = 'select a from x;\n\nselect b from y'
+    assert _remove_stmt_len_and_location(parse_sql(sql1)) == _remove_stmt_len_and_location(parse_sql(sql2))
+    assert _remove_stmt_len_and_location(parse_sql(sql1)[0]) == _remove_stmt_len_and_location(parse_sql(sql2)[0])
+    assert _remove_stmt_len_and_location(parse_sql(sql1)[1]) == _remove_stmt_len_and_location(parse_sql(sql2)[1])


### PR DESCRIPTION
Removing `stmt_location` key on `RawStmt`, as was referenced in https://github.com/lelit/pglast/blob/master/pglast/__init__.py#L64 which references [this Postgres code](https://git.postgresql.org/gitweb/?p=postgresql.git;a=blob;f=src/include/nodes/parsenodes.h;h=ecb6cd0249861bf48863a5c35d525d1d73ff89f0;hb=65c6b53991e1c56f6a0700ae26928962ddf2b9fe#l1420) which also mentions stmt_location.