### PR TITLE
Small bugfixes

### DIFF
--- a/pglast/printers/dml.py
+++ b/pglast/printers/dml.py
@@ -976,20 +976,20 @@ del MONTH, YEAR, DAY, HOUR, MINUTE, SECOND
 
 # Map system type name to generic one
 system_types = {
-    'pg_catalog.bool':        'boolean',
-    'pg_catalog.bpchar':      'char',
-    'pg_catalog.float4':      'real',
-    'pg_catalog.float8':      'double precision',
-    'pg_catalog.int2':        'smallint',
-    'pg_catalog.int4':        'integer',
-    'pg_catalog.int8':        'bigint',
-    'pg_catalog.interval':    'interval',
-    'pg_catalog.numeric':     'numeric',
-    'pg_catalog.time':        'time',
-    'pg_catalog.timestamp':   'timestamp',
-    'pg_catalog.timestamptz': 'timestamp with time zone',
-    'pg_catalog.timetz':      'time with time zone',
-    'pg_catalog.varchar':     'varchar',
+    'pg_catalog.bool':        ('boolean', ''),
+    'pg_catalog.bpchar':      ('char', ''),
+    'pg_catalog.float4':      ('real', ''),
+    'pg_catalog.float8':      ('double precision', ''),
+    'pg_catalog.int2':        ('smallint', ''),
+    'pg_catalog.int4':        ('integer', ''),
+    'pg_catalog.int8':        ('bigint', ''),
+    'pg_catalog.interval':    ('interval', ''),
+    'pg_catalog.numeric':     ('numeric', ''),
+    'pg_catalog.time':        ('time', ''),
+    'pg_catalog.timestamp':   ('timestamp', ''),
+    'pg_catalog.timestamptz': ('timestamp', ' with time zone'),
+    'pg_catalog.timetz':      ('time', ' with time zone'),
+    'pg_catalog.varchar':     ('varchar', ''),
 }
 
 
@@ -999,8 +999,10 @@ def type_name(node, output):
         # FIXME: is this used only by plpgsql?
         output.writes('SETOF')
     name = '.'.join(n.str.value for n in node.names)
+    suffix = ''
     if name in system_types:
-        output.write(system_types[name])
+        prefix, suffix = system_types[name]
+        output.write(prefix)
     else:
         output.print_name(node.names)
     if node.pct_type:
@@ -1019,6 +1021,7 @@ def type_name(node, output):
                 output.write('(')
                 output.print_list(node.typmods, ',', standalone_items=False)
                 output.write(')')
+        output.write(suffix)
         if node.arrayBounds:
             for ab in node.arrayBounds:
                 output.write('[')

--- a/pglast/printers/dml.py
+++ b/pglast/printers/dml.py
@@ -476,7 +476,10 @@ def join_expr(node, output):
 
         jt = enums.JoinType
         if node.jointype == jt.JOIN_INNER:
-            output.write('INNER')
+            if not node.usingClause and not node.quals and not node.isNatural:
+                output.write('CROSS')
+            else:
+                output.write('INNER')
         elif node.jointype == jt.JOIN_LEFT:
             output.write('LEFT')
         elif node.jointype == jt.JOIN_FULL:

--- a/tests/test_printers_roundtrip/dml/select.sql
+++ b/tests/test_printers_roundtrip/dml/select.sql
@@ -234,6 +234,8 @@ SELECT * FROM (VALUES (1),(2),(3)) v(r)
  LEFT JOIN ROWS FROM( foo_sql(11,13), foo_mat(11,13) )
  WITH ORDINALITY AS f(i1,s1,i2,s2,o) ON (r+i1+i2)<100
 
+SELECT * FROM t1 CROSS JOIN t2
+
 SELECT i.q1, i.q2, ss.column1
 FROM int8_tbl i, LATERAL (VALUES (i.*::int8_tbl)) ss
 

--- a/tests/test_printers_roundtrip/dml/select.sql
+++ b/tests/test_printers_roundtrip/dml/select.sql
@@ -368,6 +368,10 @@ ORDER BY sp.name
 
 SELECT CAST(1.234 AS NUMERIC(5,2))
 
+SELECT now()::time(0) with time zone
+
+SELECT now()::timestamp(0) with time zone
+
 SELECT
   pc.id,
   pc.person_id,


### PR DESCRIPTION
Hello,

Thank you for merging the previous PR.

I have two new changes:
 - support for CROSS JOINs. They were emitted as INNER JOINs, but without a matching ON clause the result was unparseable.
 - support for modifiers for time with time zone and timestamp with time zone datatypes. I was wondering whether we should emit them as timetz / timestamptz or implement this workaround.