### PR TITLE
Add support for variadic functions

### DIFF
--- a/pglast/printers/dml.py
+++ b/pglast/printers/dml.py
@@ -343,7 +343,14 @@ def func_call(node, output):
         if node.agg_star:
             output.write('*')
     else:
-        output.print_list(node.args)
+        if node.func_variadic:
+            if len(node.args) > 1:
+                output.print_list(node.args[:-1])
+                output.write(', ')
+            output.write('VARIADIC ')
+            output.print_node(node.args[-1])
+        else:
+            output.print_list(node.args)
     if node.agg_order:
         if node.agg_within_group is Missing:
             output.swrites('ORDER BY')
@@ -359,7 +366,6 @@ def func_call(node, output):
     if node.over:
         output.swrite('OVER ')
         output.print_node(node.over)
-
 
 @node_printer('GroupingSet')
 def grouping_set(node, output):

--- a/tests/test_printers_roundtrip/dml/select.sql
+++ b/tests/test_printers_roundtrip/dml/select.sql
@@ -420,3 +420,7 @@ SELECT a < ('foo' COLLATE "fr_FR") FROM test1
 SELECT a < b COLLATE "de_DE" FROM test1
 
 SELECT * FROM test1 ORDER BY a || b COLLATE "fr_FR"
+
+SELECT variadic_function(VARIADIC ARRAY['param1']);
+
+SELECT variadic_function('value1', VARIADIC ARRAY['param2']);


### PR DESCRIPTION
PostgreSQL support the VARIADIC keyword, for calling variadic functions with an array instead of a variable-length parameter list.