### PR TITLE
Fix bug with SETOF <some_type> without any parameters

### DIFF
--- a/pglast/printers/ddl.py
+++ b/pglast/printers/ddl.py
@@ -773,7 +773,7 @@ def create_function_stmt(node, output):
         fpm = enums.FunctionParameterMode
         record_def = []
         real_params = []
-        for param in node.parameters:
+        for param in node.parameters or []:
             if param.mode == fpm.FUNC_PARAM_TABLE:
                 record_def.append(Node(
                     {'ColumnDef': {

--- a/tests/test_printers_roundtrip/ddl/create_function.sql
+++ b/tests/test_printers_roundtrip/ddl/create_function.sql
@@ -22,3 +22,5 @@ LANGUAGE C
 CREATE FUNCTION funcc(arg text = 'default_val', OUT arg2 text, INOUT arg3 text, VARIADIC
 arglist text[]) RETURNS SETOF integer AS $$
 $$ language sql
+
+CREATE FUNCTION func() RETURNS SETOF montype AS $$ $$ language sql


### PR DESCRIPTION
I had an oversight in the initial implementation of CreateFunctionStmt.

When there is a SETOF return type, if it's not actually a properly defined type but a record we have to look for its definition in the function parameters.

In the case of a "proper" type, there is no need for that, which isn't harmful unless the function doesn't have any parameters.