### PR TITLE
Fix function body dollar quoting

### DIFF
--- a/pglast/printers/ddl.py
+++ b/pglast/printers/ddl.py
@@ -822,7 +822,7 @@ def create_function_option(node, output):
         # Choose a valid dollar-string delimiter
 
         code = node.arg.string_value
-        used_delimiters = set(re.findall(r"\$(\w*)\$", code))
+        used_delimiters = set(re.findall(r"\$(\w*)(?=\$)", code))
         unique_delimiter = ''
         while unique_delimiter in used_delimiters:
             unique_delimiter += '_'

--- a/tests/test_printers_prettification/ddl/create_function.sql
+++ b/tests/test_printers_prettification/ddl/create_function.sql
@@ -49,3 +49,15 @@ BEGIN
   RETURN new;
 END;
 $$ LANGUAGE plpgsql
+
+CREATE FUNCTION func()
+RETURNS void
+AS '
+    SELECT $_$$_$;
+' LANGUAGE sql
+=
+CREATE FUNCTION func()
+RETURNS void
+AS $__$
+    SELECT $_$$_$;
+$__$ LANGUAGE sql


### PR DESCRIPTION
The current regex fails to detect the `$$` in the empty string `$_$$_$`
because it consumes the last dollar and matches cannot overlap. Use a
lookahead for the last dollar to fix this.