### PR TITLE
Support schema name in collation

### DIFF
--- a/pglast/printers/dml.py
+++ b/pglast/printers/dml.py
@@ -284,7 +284,7 @@ def collate_clause(node, output):
     if node.arg:
         output.print_node(node.arg)
     output.swrite('COLLATE ')
-    output.print_name(node.collname, ',')
+    output.print_name(node.collname, '.')
 
 
 @node_printer('ColumnRef')

--- a/tests/test_printers_roundtrip/ddl/create_table.sql
+++ b/tests/test_printers_roundtrip/ddl/create_table.sql
@@ -54,6 +54,8 @@ create table a (
 
 CREATE TABLE a(t text collate "C")
 
+CREATE TABLE a(t text collate pg_catalog."C" NOT NULL)
+
 CREATE TABLE ages (
   id integer primary key,
   age1 interval year,


### PR DESCRIPTION
Names in collation name were separated by commas instead of a dot, thus printing incorrect collation names. 

This PR is for the master branch, I will open another one with the same commit for the v2 branch.