### PR TITLE
Optional lexpr in A_Expr printer

### DIFF
--- a/Makefile.virtualenv
+++ b/Makefile.virtualenv
@@ -42,7 +42,7 @@ requirements: $(REQUIREMENTS_TIMESTAMP)
 
 $(REQUIREMENTS_TIMESTAMP): $(REQUIREMENTS)
 	@echo "Installing pre-requirements..."
-	@PATH=$(TOPDIR)/bin:$(PATH) $(PIP) install --no-cache-dir -r $(REQUIREMENTS)
+	@PATH=$(TOPDIR)/bin:"$(PATH)" $(PIP) install --no-cache-dir -r $(REQUIREMENTS)
 	@touch $@
 
 distclean::

--- a/pglast/printers/dml.py
+++ b/pglast/printers/dml.py
@@ -30,12 +30,14 @@ def a_expr(node, output):
 
     if node.kind == aek.AEXPR_OP:
         with output.expression():
-            if node.lexpr.node_tag == 'A_Expr':
-                with output.expression():
+            # lexpr is optional because these are valid: -(1+1), +(1+1), ~(1+1)
+            if node.lexpr is not Missing:
+                if node.lexpr.node_tag == 'A_Expr':
+                    with output.expression():
+                        output.print_node(node.lexpr)
+                else:
                     output.print_node(node.lexpr)
-            else:
-                output.print_node(node.lexpr)
-            output.write(' ')
+                output.write(' ')
             if isinstance(node.name, List) and len(node.name) > 1:
                 output.write('OPERATOR(')
                 output.print_symbol(node.name)

--- a/tests/test_printers_roundtrip/dml/select.sql
+++ b/tests/test_printers_roundtrip/dml/select.sql
@@ -435,3 +435,9 @@ SELECT * FROM test1 ORDER BY a || b COLLATE "fr_FR"
 SELECT variadic_function(VARIADIC ARRAY['param1']);
 
 SELECT variadic_function('value1', VARIADIC ARRAY['param2']);
+
+SELECT -(1+1);
+
+SELECT +(1+1);
+
+SELECT ~(1+1);


### PR DESCRIPTION
Fixes #53 

This allows lexpr to be missing in A_Expr printer so it can print queries like `SELECT -(1+1)`.

Notes:
- As far as I can tell this is only appropriate for `AEXPR_OP`, not the other expression kinds.
- I considered raising an Exception if node.name isn't -, +, or ~ but I'm worried there are other valid cases I don't know about so I left it more permissive.
- Wrapped $PATH in the Makefile with quotes to handle spaces. I couldn't run make commands without this. Happy to split into another PR if strictly necessary.
- I'm targeting master instead of v2 since its a bug fix that applies to v1.