### PR TITLE
Add option --remove_pg_catalog_from_functions

### DIFF
--- a/pglast/__main__.py
+++ b/pglast/__main__.py
@@ -40,6 +40,7 @@ def workhorse(args):
                 split_string_literals_threshold=args.split_string_literals,
                 special_functions=args.special_functions,
                 comma_at_eoln=args.comma_at_eoln,
+                remove_pg_catalog_from_functions=args.remove_pg_catalog_from_functions,
                 semicolon_after_last_statement=args.semicolon_after_last_statement)
         except Error as e:
             print()
@@ -86,7 +87,9 @@ def main(options=None):
                         help='a file containing the SQL statement to be pretty-printed,'
                         ' by default stdin, when not specified with --statement option')
     parser.add_argument('outfile', nargs='?', type=argparse.FileType('w'),
-                        help='where the result will be written, by default stdout')
+                        help='where the result will be written, by default stdout'),
+    parser.add_argument('-F', '--remove_pg_catalog_from_functions', action='store_true', default=False,
+                        help='remove pg_catalog from functions'),
 
     args = parser.parse_args(options if options is not None else sys.argv[1:])
 

--- a/pglast/__main__.py
+++ b/pglast/__main__.py
@@ -83,13 +83,13 @@ def main(options=None):
                         default=False, help="preserve comments in the statement")
     parser.add_argument('-S', '--statement',
                         help='the SQL statement')
+    parser.add_argument('-F', '--remove-pg_catalog-from-functions', action='store_true', default=False,
+                        help='remove pg_catalog from functions')
     parser.add_argument('infile', nargs='?', type=argparse.FileType(),
                         help='a file containing the SQL statement to be pretty-printed,'
                         ' by default stdin, when not specified with --statement option')
     parser.add_argument('outfile', nargs='?', type=argparse.FileType('w'),
-                        help='where the result will be written, by default stdout'),
-    parser.add_argument('-F', '--remove_pg_catalog_from_functions', action='store_true', default=False,
-                        help='remove pg_catalog from functions'),
+                        help='where the result will be written, by default stdout')
 
     args = parser.parse_args(options if options is not None else sys.argv[1:])
 

--- a/pglast/stream.py
+++ b/pglast/stream.py
@@ -370,7 +370,7 @@ class RawStream(OutputStream):
             # The list contains all functions that cannot be found without an
             # explicit pg_catalog schema. ie:
             # position(a,b) is invalid but pg_catalog.position(a,b) is fine
-            and items[1].val.value not in ['position']
+            and items[1].val.value not in ('position',)
         )
 
     def _print_items(self, items, sep, newline, are_names=False, is_symbol=False):

--- a/pglast/stream.py
+++ b/pglast/stream.py
@@ -367,6 +367,7 @@ class RawStream(OutputStream):
             and items.parent_attribute == 'funcname'
             and len(items) > 1
             and items[0].val.value == 'pg_catalog'
+            and items[1].val.value not in ['position']
         )
 
     def _print_items(self, items, sep, newline, are_names=False, is_symbol=False):

--- a/pglast/stream.py
+++ b/pglast/stream.py
@@ -367,6 +367,9 @@ class RawStream(OutputStream):
             and items.parent_attribute == 'funcname'
             and len(items) > 1
             and items[0].val.value == 'pg_catalog'
+            # The list contains all functions that cannot be found without an
+            # explicit pg_catalog schema. ie:
+            # position(a,b) is invalid but pg_catalog.position(a,b) is fine
             and items[1].val.value not in ['position']
         )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -126,7 +126,14 @@ SELECT 'abc'
                                          "     , count(*)\n"
                                          "FROM t1\n")
 
-    with StringIO("select substring('123',2,3), regexp_split_to_array('x,x,x', ','), btrim('xxx'), trim('xxx'), POSITION('hour' in trim(substring('xyz hour ',1,6)))") as input:
+    in_stmt = """\
+select substring('123',2,3),
+       regexp_split_to_array('x,x,x', ','),
+       btrim('xxx'), trim('xxx'),
+       POSITION('hour' in trim(substring('xyz hour ',1,6)))
+"""
+
+    with StringIO(in_stmt) as input:
         with UnclosableStream() as output:
             with redirect_stdin(input), redirect_stdout(output):
                 main(['--compact-lists-margin', '100'])
@@ -138,7 +145,7 @@ SELECT pg_catalog.substring('123', 2, 3)
      , pg_catalog.position(pg_catalog.btrim(pg_catalog.substring('xyz hour ', 1, 6)), 'hour')
 """
 
-    with StringIO("select substring('123',2,3), regexp_split_to_array('x,x,x', ','), btrim('xxx'), trim('xxx'), POSITION('hour' in trim(substring('xyz hour ',1,6)))") as input:
+    with StringIO(in_stmt) as input:
         with UnclosableStream() as output:
             with redirect_stdin(input), redirect_stdout(output):
                 main(['--remove-pg_catalog-from-functions', '--compact-lists-margin', '100'])
@@ -149,5 +156,3 @@ SELECT substring('123', 2, 3)
      , btrim('xxx')
      , pg_catalog.position(btrim(substring('xyz hour ', 1, 6)), 'hour')
 """
-
-

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -141,7 +141,7 @@ SELECT pg_catalog.substring('123', 2, 3)
     with StringIO("select substring('123',2,3), regexp_split_to_array('x,x,x', ','), btrim('xxx'), trim('xxx'), POSITION('hour' in trim(substring('xyz hour ',1,6)))") as input:
         with UnclosableStream() as output:
             with redirect_stdin(input), redirect_stdout(output):
-                main(['--remove_pg_catalog_from_functions', '--compact-lists-margin', '100'])
+                main(['--remove-pg_catalog-from-functions', '--compact-lists-margin', '100'])
             assert output.getvalue() == """\
 SELECT substring('123', 2, 3)
      , regexp_split_to_array('x,x,x', ',')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -125,3 +125,27 @@ SELECT 'abc'
             assert output.getvalue() == ("SELECT EXTRACT(HOUR FROM t1.modtime)\n"
                                          "     , count(*)\n"
                                          "FROM t1\n")
+
+    with StringIO("select substring('123',2,3), regexp_split_to_array('x,x,x', ','), btrim('xxx'), trim('xxx'), POSITION('hour' in trim(substring('xyz hour ',1,6)))") as input:
+        with UnclosableStream() as output:
+            with redirect_stdin(input), redirect_stdout(output):
+                main(['--compact-lists-margin', '100'])
+            assert output.getvalue() == """\
+SELECT pg_catalog.substring('123', 2, 3)
+     , regexp_split_to_array('x,x,x', ',')
+     , btrim('xxx')
+     , pg_catalog.btrim('xxx')
+     , pg_catalog.position(pg_catalog.btrim(pg_catalog.substring('xyz hour ', 1, 6)), 'hour')
+"""
+
+    with StringIO("select substring('123',2,3), regexp_split_to_array('x,x,x', ','), btrim('xxx'), trim('xxx'), POSITION('hour' in trim(substring('xyz hour ',1,6)))") as input:
+        with UnclosableStream() as output:
+            with redirect_stdin(input), redirect_stdout(output):
+                main(['--remove_pg_catalog_from_functions', '--compact-lists-margin', '100'])
+            assert output.getvalue() == """\
+SELECT substring('123', 2, 3)
+     , regexp_split_to_array('x,x,x', ',')
+     , btrim('xxx')
+     , btrim('xxx')
+     , position(btrim(substring('xyz hour ', 1, 6)), 'hour')
+"""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -147,5 +147,7 @@ SELECT substring('123', 2, 3)
      , regexp_split_to_array('x,x,x', ',')
      , btrim('xxx')
      , btrim('xxx')
-     , position(btrim(substring('xyz hour ', 1, 6)), 'hour')
+     , pg_catalog.position(btrim(substring('xyz hour ', 1, 6)), 'hour')
 """
+
+


### PR DESCRIPTION
The new option removes the pg_catalog schema before function calls.
These may occur when PG replaces the desired function with an
adequate other function.

```
# output without the new option

❯ pgpp -m 100 -S "select substring('123',2,3), btrim('xxx'), trim('xxx'), POSITION('hour' in trim(substring('xyz hour ',1,6)))"
SELECT pg_catalog.substring('123', 2, 3)
     , btrim('xxx')
     , pg_catalog.btrim('xxx')
     , pg_catalog.position(pg_catalog.btrim(pg_catalog.substring('xyz hour ', 1, 6)), 'hour')

# new output with -F

❯ pgpp -F -m 100 -S "select substring('123',2,3), btrim('xxx'), trim('xxx'), POSITION('hour' in trim(substring('xyz hour ',1,6)))"
SELECT substring('123', 2, 3)
     , btrim('xxx')
     , btrim('xxx')
     , pg_catalog.position(btrim(substring('xyz hour ', 1, 6)), 'hour')
```