### PR TITLE
Add more special_functions

### DIFF
--- a/pglast/printers/sfuncs.py
+++ b/pglast/printers/sfuncs.py
@@ -8,6 +8,12 @@
 
 from . import special_function
 
+# reminder for not yet implemented special functions:
+#
+# treat(1 as int)
+# 'foo' is nfc normalized
+# 'foo' is not nfc normalized
+
 
 def _print_trim(where, node, output):
     output.write('trim({}'.format(where))

--- a/pglast/printers/sfuncs.py
+++ b/pglast/printers/sfuncs.py
@@ -9,6 +9,33 @@
 from . import special_function
 
 
+def _print_trim(where, node, output):
+    output.write('trim({}'.format(where))
+    if len(node.args) > 1:
+        output.write(' ')
+        output.print_node(node.args[1])
+    output.write(' FROM ')
+    output.print_node(node.args[0])
+    output.write(')')
+
+
+@special_function('pg_catalog.btrim')
+def btrim(node, output):
+    """
+    Emit function ``pg_catalog.btrim('  abc  ')`` as ``trim(BOTH FROM '  abc  ')``
+    and ``pg_catalog.btrim('xxabcxx', 'x')`` as ``trim(BOTH 'x' FROM 'xxabcxx')``
+    """
+    _print_trim('BOTH', node, output)
+
+
+@special_function('pg_catalog.pg_collation_for')
+def pg_collation_for(node, output):
+    "Emit function ``pg_catalog.pg_collation_for(x)`` as ``COLLATION FOR (x)``."
+    output.write('COLLATION FOR (')
+    output.print_node(node.args[0])
+    output.write(')')
+
+
 @special_function('pg_catalog.date_part')
 def date_part(node, output):
     """
@@ -22,6 +49,28 @@ def date_part(node, output):
     output.write(')')
 
 
+@special_function('pg_catalog.ltrim')
+def ltrim(node, output):
+    """
+    Emit function ``pg_catalog.ltrim('  abc  ')`` as ``trim(LEADING FROM '  abc  ')``
+    and ``pg_catalog.ltrim('xxabcxx', 'x')`` as ``trim(LEADING 'x' FROM 'xxabcxx')``
+    """
+    _print_trim('LEADING', node, output)
+
+
+# normalize(U&'\0061\0308bc', NFC)
+@special_function('pg_catalog.normalize')
+def normalize(node, output):
+    "Emit function ``pg_catalog.normalize(a)`` as ``normalize(x)``."
+    "Emit function ``pg_catalog.normalize('a','b')`` as ``normalize('a', b)``."
+    output.write('normalize(')
+    output.print_node(node.args[0])
+    if len(node.args) > 1:
+        output.write(', ')
+        output.write(node.args[1].val.val.value.upper())
+    output.write(')')
+
+
 @special_function('pg_catalog.overlaps')
 def overlaps(node, output):
     "Emit function ``pg_catalog.overlaps(a, b, c, d)`` as ``(a, b) OVERLAPS (c, d)``."
@@ -29,6 +78,58 @@ def overlaps(node, output):
     output.print_list((node.args[0], node.args[1]), standalone_items=False)
     output.write(') OVERLAPS (')
     output.print_list((node.args[2], node.args[3]), standalone_items=False)
+    output.write(')')
+
+
+@special_function('pg_catalog.overlay')
+def overlay(node, output):
+    """
+    Emit function ``pg_catalog.overlay('Txxxxas','hom', 2, 4)`` as
+    ``overlay('Txxxxas' PLACING 'hom' FROM 2 FOR 4)``."
+    """
+    output.write('overlay(')
+    output.print_node(node.args[0])
+    output.write(' PLACING ')
+    output.print_node(node.args[1])
+    output.write(' FROM ')
+    output.print_node(node.args[2])
+    output.write(' FOR ')
+    output.print_node(node.args[3])
+    output.write(')')
+
+
+@special_function('pg_catalog.position')
+def position(node, output):
+    "Emit function ``pg_catalog.position('abcd', 'a')`` as ``position('a' IN 'abcd')``."
+    output.write('position(')
+    output.print_node(node.args[1])
+    output.write(' IN ')
+    output.print_node(node.args[0])
+    output.write(')')
+
+
+@special_function('pg_catalog.rtrim')
+def rtrim(node, output):
+    """
+    Emit function ``pg_catalog.rtrim('  abc  ')`` as ``trim(TRAILING FROM '  abc  ')``
+    and ``pg_catalog.rtrim('xxabcxx', 'x')`` as ``trim(TRAILING 'x' FROM 'xxabcxx')``
+    """
+    _print_trim('TRAILING', node, output)
+
+
+@special_function('pg_catalog.substring')
+def substring(node, output):
+    """
+    Emit function ``pg_catalog.substring('Txxxxas', 2, 4)`` as ``substring('Txxxxas' FROM 2 FOR 4)``.
+    and ``pg_catalog.substring('blabla', 2)`` as ``substring('blabla' FROM 2)``.
+"""
+    output.write('substring(')
+    output.print_node(node.args[0])
+    output.write(' FROM ')
+    output.print_node(node.args[1])
+    if len(node.args) > 2:
+        output.write(' FOR ')
+        output.print_node(node.args[2])
     output.write(')')
 
 
@@ -40,3 +141,13 @@ def timezone(node, output):
     output.print_node(node.args[1])
     output.write(' AT TIME ZONE ')
     output.print_node(node.args[0])
+
+
+@special_function('pg_catalog.xmlexists')
+def xmlexists(node, output):
+    "Emit function ``pg_catalog.xmlexists(x, y)`` as ``xmlexists(x PASSING BY REF y)``."
+    output.write('xmlexists(')
+    output.print_node(node.args[0])
+    output.write(' PASSING BY REF ')
+    output.print_node(node.args[1])
+    output.write(')')

--- a/pglast/stream.py
+++ b/pglast/stream.py
@@ -377,7 +377,7 @@ class RawStream(OutputStream):
             # The list contains all functions that cannot be found without an
             # explicit pg_catalog schema. ie:
             # position(a,b) is invalid but pg_catalog.position(a,b) is fine
-            and items[1].val.value not in ('position',)
+            and items[1].val.value not in ('position', 'xmlexists')
         )
 
     def _print_items(self, items, sep, newline, are_names=False, is_symbol=False):


### PR DESCRIPTION
Add missing special-functions for position, overlay, substring and trim

```
pgpp with --special-functions can emit something like:

SELECT substring('abcd' FROM 1 FOR 2)
     , substring('abcd' FROM 2)
     , position('bc' IN 'abcd')
     , trim(BOTH FROM '  abc  ')
     , trim(BOTH '*' FROM '***abc***')
     , trim(LEADING '*' FROM '***abc***')
     , trim(TRAILING '*' FROM '***abc***')
     , overlay('Txxxxas' PLACING 'hom' FROM 2 FOR 4)
```