### PR TITLE
feat: define default visit method for visitor

### DIFF
--- a/pglast/visitors.py
+++ b/pglast/visitors.py
@@ -387,11 +387,11 @@ class Visitor:
             if pending_update.member is None:
                 self.root = pending_update.node
 
-    visit = None
-    """
-    The default *visit* method for any node without a specific one.
-    When ``None``, nothing happens.
-    """
+    def visit(self, ancestors, node):
+        """
+        The default *visit* method for any node without a specific one.
+        When ``None``, nothing happens.
+        """
 
 
 class ReferencedRelations(Visitor):

--- a/pglast/visitors.py
+++ b/pglast/visitors.py
@@ -279,8 +279,7 @@ class Visitor:
     instance or a sequence of instances, typically the result of :func:`parse_sql
     <pglast.parser.parse_sql>`. The argument will be *traversed* in a `breadth first`__ order
     and each :class:`Node <.ast.Node>` instance will be passed to the corresponding
-    ``visit_XYZ`` method if it is implemented, falling back to the default ``visit`` method. If
-    none of them are defined, the node will be ignored.
+    ``visit_XYZ`` method if it is implemented, falling back to the default ``visit`` method.
 
     The ``visit_XYZ`` methods receive two arguments: the *ancestry chain* of the node, an
     instance of :class:`Ancestor` and the :class:`Node <.ast.Node>` instance itself. The
@@ -390,7 +389,6 @@ class Visitor:
     def visit(self, ancestors, node):
         """
         The default *visit* method for any node without a specific one.
-        When ``None``, nothing happens.
         """
 
 


### PR DESCRIPTION
## Description

This change fixes the typing inconsistency in the visitor base class by replacing the dynamically assigned `visit = None` attribute with a properly defined method signature.

Previously, the base class exposed visit as an attribute:
```python
visit = None
```
while subclasses can either choose to implement/override it as a concrete method:
```python
def visit(self, ancestors: visitors.Ancestor, node: ast.Node) -> None:
```

This then creates a divergence between the superclass and subclass definitions:
 - superclass treats visit as an optional attribute/callback
- subclasses treated visit as an actual overridable method

Although this worked at runtime due to Python’s dynamic nature, static type checkers such as mypy interpreted the superclass contract differently and reported errors similar to:
```bash
Signature of "visit" incompatible with supertype "Visitor"  [override]
```
because the superclass did not define a real method signature to override.

This PR resolves the issue by defining `visit()` as an explicit `no-op` method in the base class, establishing a consistent and type-safe inheritance contract for subclasses.