### PR TITLE
Implement visitor Add action

### DIFF
--- a/pglast/visitors.py
+++ b/pglast/visitors.py
@@ -28,7 +28,12 @@ class Action(metaclass=ActionMeta):
 
 
 class Add(Action):
-    "Marker used to tell the iterator to insert nodes in the current sequence."
+    """
+    Marker used to tell the iterator to insert nodes in the current sequence.
+
+    Return ``(Add, node, ...)`` from a visitor to insert one or more nodes after
+    the current one.
+    """
 
 
 class Continue(Action):
@@ -229,6 +234,7 @@ class Ancestor:
     def update(self, new_value):
         "Set `new_value` as a pending change to the tracked node."
 
+        is_add = isinstance(new_value, (tuple, list)) and new_value and new_value[0] is Add
         if isinstance(self.member, int):
             # We are pointing to one particular item in a tuple, so we need to build a new one,
             # replacing it with the new value and then update the parent node accordingly:
@@ -237,9 +243,16 @@ class Ancestor:
             # lists" cases, that are handled at apply time.
             if self.parent.pending_update is None:
                 self.parent.pending_update = list(self.node)
+            if is_add:
+                new_value = (
+                    Add,
+                    self.parent.pending_update[self.member],
+                ) + tuple(new_value[1:])
             self.parent.pending_update[self.member] = new_value
             return self.parent
         else:
+            if is_add:
+                raise ValueError('Add action can only be used with nodes in a sequence')
             self.pending_update = new_value
             return self
 
@@ -248,7 +261,15 @@ class Ancestor:
 
         if self.pending_update is not None:
             if isinstance(self.pending_update, list):
-                value = tuple(filter(lambda item: item is not Delete, self.pending_update))
+                new_value = []
+                for item in self.pending_update:
+                    if item is Delete:
+                        continue
+                    if isinstance(item, tuple) and item and item[0] is Add:
+                        new_value.extend(item[1:])
+                    else:
+                        new_value.append(item)
+                value = tuple(new_value)
             else:
                 value = self.pending_update
             if isinstance(self.member, int):
@@ -373,6 +394,14 @@ class Visitor:
                                 todo.append((sub_ancestors / (sub_node, member), value))
                     elif action is Skip:
                         pass
+                    elif (isinstance(action, (tuple, list))
+                          and action
+                          and action[0] is Add):
+                        if len(action) < 2:
+                            raise ValueError('Add action requires one or more nodes to insert')
+                        pending_updates.append(sub_ancestors.update(action))
+                    elif action is Add:
+                        raise ValueError('Add action requires one or more nodes to insert')
                     else:
                         pending_updates.append(sub_ancestors.update(action))
                 elif isinstance(sub_node, tuple):

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -279,6 +279,81 @@ def test_delete_action():
     assert RawStream()(raw) == ''
 
 
+def test_add_action():
+    class AddMissingSelectTargets(visitors.Visitor):
+        def visit_ResTarget(self, ancestors, node):
+            if isinstance(node.val, ast.A_Const) and node.val.val.ival == 1:
+                return (
+                    visitors.Add,
+                    ast.ResTarget(val=ast.A_Const(val=ast.Integer(2))),
+                    ast.ResTarget(val=ast.A_Const(val=ast.Integer(3))),
+                )
+
+    raw = parse_sql('select 1')
+    AddMissingSelectTargets()(raw)
+    assert RawStream()(raw) == 'SELECT 1, 2, 3'
+
+    class AddEvenValueAfterOdd(visitors.Visitor):
+        def visit_A_Const(self, ancestors, node):
+            if isinstance(node.val, ast.Integer) and node.val.ival == 1:
+                return visitors.Add, ast.A_Const(val=ast.Integer(2))
+
+    raw = parse_sql('INSERT INTO foo VALUES (1, 3)')
+    AddEvenValueAfterOdd()(raw)
+    assert RawStream()(raw) == 'INSERT INTO foo VALUES (1, 2, 3)'
+
+    class AddMultipleValues(visitors.Visitor):
+        def visit_A_Const(self, ancestors, node):
+            if isinstance(node.val, ast.Integer):
+                return visitors.Add, ast.A_Const(val=ast.Integer(node.val.ival * 10))
+
+    raw = parse_sql('INSERT INTO foo VALUES (1, 2, 3)')
+    AddMultipleValues()(raw)
+    assert RawStream()(raw) == 'INSERT INTO foo VALUES (1, 10, 2, 20, 3, 30)'
+
+    class AddAndDeleteValues(visitors.Visitor):
+        def visit_A_Const(self, ancestors, node):
+            if isinstance(node.val, ast.Integer):
+                if node.val.ival == 1:
+                    return visitors.Add, ast.A_Const(val=ast.Integer(10))
+                if node.val.ival == 2:
+                    return visitors.Delete
+
+    raw = parse_sql('INSERT INTO foo VALUES (1, 2, 3)')
+    AddAndDeleteValues()(raw)
+    assert RawStream()(raw) == 'INSERT INTO foo VALUES (1, 10, 3)'
+
+    class AddSecondStatement(visitors.Visitor):
+        def visit_RawStmt(self, ancestors, node):
+            if isinstance(node.stmt, ast.SelectStmt):
+                return visitors.Add, parse_sql('select 2')[0]
+
+    raw = parse_sql('select 1')
+    new_raw = AddSecondStatement()(raw)
+    assert RawStream()(new_raw) == 'SELECT 1; SELECT 2'
+
+    class BareAdd(visitors.Visitor):
+        def visit_A_Const(self, ancestors, node):
+            return visitors.Add
+
+    with pytest.raises(ValueError, match='requires one or more nodes'):
+        BareAdd()(parse_sql('select 1'))
+
+    class EmptyAdd(visitors.Visitor):
+        def visit_A_Const(self, ancestors, node):
+            return (visitors.Add,)
+
+    with pytest.raises(ValueError, match='requires one or more nodes'):
+        EmptyAdd()(parse_sql('select 1'))
+
+    class AddInsideAttribute(visitors.Visitor):
+        def visit_A_Const(self, ancestors, node):
+            return visitors.Add, ast.A_Const(val=ast.Integer(2))
+
+    with pytest.raises(ValueError, match='can only be used with nodes in a sequence'):
+        AddInsideAttribute()(parse_sql('select 1'))
+
+
 def test_alter_node():
     class AddNullConstraint(visitors.Visitor):
         def visit_ColumnDef(self, ancestors, node):


### PR DESCRIPTION
visitors.Add was documented as a visitor action for inserting nodes after the current node, but the visitor machinery never actually handled it. Returning (visitors.Add, node) from a visitor was treated like a normal replacement value, not an insertion request. The fix wires that documented action into the existing pending-update flow so visitors can add nodes to statement/target/value sequences.





