### PR TITLE
Fix string literal splitting on trailing backslash

### DIFF
--- a/pglast/stream.py
+++ b/pglast/stream.py
@@ -702,7 +702,7 @@ class IndentedStream(RawStream):
                     chunk = s[:sslt]
                     s = s[sslt:]
                     # Avoid splitting on backslash
-                    while chunk.endswith("\\"):
+                    while s and chunk.endswith("\\"):
                         chunk += s[0]
                         s = s[1:]
                     chunk = chunk.replace("'", "''")

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -86,6 +86,18 @@ def test_indented_stream_with_sql():
             NODE_PRINTERS.pop(ast.RawStmt, None)
 
 
+@pytest.mark.parametrize('sql,threshold,expected', (
+    ("SELECT 'abc\\'", 4, "SELECT 'abc\\'"),
+    ("SELECT 'abc\\'", 3, "SELECT 'abc'\n       '\\'"),
+    (r"SELECT 'abc\\'", 3, "SELECT 'abc'\n       '\\\\'"),
+    ("SELECT 'abc\n\\'", 3, "SELECT E'abc'\n        '\\n\\\\'"),
+))
+def test_split_string_literals_ending_in_backslash(sql, threshold, expected):
+    result = IndentedStream(split_string_literals_threshold=threshold)(parse_sql(sql))
+
+    assert result == expected
+
+
 def test_separate_statements():
     """Separate statements by ``separate_statements`` (int) newlines."""
     raw_stmt_printer = NODE_PRINTERS.pop(ast.RawStmt, None)


### PR DESCRIPTION
IndentedStream tries not to split string literals immediately after a backslash, so it peeks at the next character and moves it into the current chunk. That works unless the chunk ending in \ is already the final chunk. In that case there is no next character left, so the code reads s[0] from an empty string and crashes with IndexError.

The fix just makes that peek conditional: only pull another character when there actually is one. It keeps the existing “don’t split after backslash when possible” behavior, but lets a final trailing backslash print normally instead of crashing.