### PR TITLE
Preserve SQL-syntax function roundtrips

### DIFF
--- a/pglast/printers/dml.py
+++ b/pglast/printers/dml.py
@@ -676,7 +676,7 @@ def float(node, output):
 @node_printer(ast.FuncCall)
 def func_call(node, output):
     name = '.'.join(n.sval for n in node.funcname)
-    special_printer = output.get_printer_for_function(name)
+    special_printer = output.get_printer_for_function(name, node)
     if special_printer is not None:
         special_printer(node, output)
         return

--- a/pglast/stream.py
+++ b/pglast/stream.py
@@ -11,13 +11,16 @@ from io import StringIO
 from re import compile
 from sys import stderr
 
-from . import ast, parse_plpgsql, parse_sql
+from . import ast, enums, parse_plpgsql, parse_sql
 from .keywords import RESERVED_KEYWORDS, TYPE_FUNC_NAME_KEYWORDS
 from .printers import get_printer_for_node, get_special_function
 
 
 is_simple_name = compile(r'[a-z_][a-z0-9_]*$').match
 "Determine whether a name is simple enough to not require being double quoted."
+
+
+SQL_SYNTAX_SPECIAL_FUNCTIONS = frozenset(('pg_catalog.extract', 'pg_catalog.position'))
 
 
 def maybe_double_quote_name(name):
@@ -214,17 +217,21 @@ class RawStream(OutputStream):
     def dedent(self):
         "Do nothing, shall be overridden by the prettifier subclass."
 
-    def get_printer_for_function(self, name):
+    def get_printer_for_function(self, name, node=None):
         """Look for a specific printer for function `name` in :data:`SPECIAL_FUNCTIONS`.
 
         :param str name: the qualified name of the function
         :returns: either ``None`` or a callable
 
         When the option `special_functions` is ``True``, return the printer function associated
-        with `name`, if present. In all other cases return ``None``.
+        with `name`, if present. For functions whose comma-call form is distinct from their
+        SQL syntax form, also return the printer when the parsed node used SQL syntax.
         """
 
-        if self.special_functions:
+        if (self.special_functions
+                or (node is not None
+                    and name in SQL_SYNTAX_SPECIAL_FUNCTIONS
+                    and node.funcformat == enums.CoercionForm.COERCE_SQL_SYNTAX)):
             return get_special_function(name)
 
     def indent(self, amount=0, relative=True):
@@ -416,7 +423,7 @@ class RawStream(OutputStream):
             # The list contains all functions that cannot be found without an
             # explicit pg_catalog schema. ie:
             # position(a,b) is invalid but pg_catalog.position(a,b) is fine
-            and items[1].sval not in ('position', 'xmlexists')
+            and items[1].sval not in ('extract', 'position', 'xmlexists')
         )
 
     def _print_items(self, items, sep, newline, are_names=False, is_symbol=False,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -202,7 +202,7 @@ SELECT substring('123', 2, 3)
      , regexp_split_to_array('x,x,x', ',')
      , btrim('xxx')
      , pg_catalog.btrim('xxx')
-     , pg_catalog.position(pg_catalog.btrim(substring('xyz hour ', 1, 6)), 'hour')
+     , position('hour' IN pg_catalog.btrim(substring('xyz hour ', 1, 6)))
 """
 
     with StringIO(in_stmt) as input:
@@ -214,7 +214,7 @@ SELECT substring('123', 2, 3)
      , regexp_split_to_array('x,x,x', ',')
      , btrim('xxx')
      , btrim('xxx')
-     , pg_catalog.position(btrim(substring('xyz hour ', 1, 6)), 'hour')
+     , position('hour' IN btrim(substring('xyz hour ', 1, 6)))
 """
 
     with StringIO('SELECT NULLIF(1, 0)') as input:

--- a/tests/test_printers_prettification/dml/issue189.sql
+++ b/tests/test_printers_prettification/dml/issue189.sql
@@ -1,7 +1,6 @@
 select extract(epoch from now())
 =
-SELECT pg_catalog.extract('epoch'
-                        , now())
+SELECT EXTRACT(EPOCH FROM now())
 
 select extract(epoch from now())
 =

--- a/tests/test_printers_prettification/dml/select.sql
+++ b/tests/test_printers_prettification/dml/select.sql
@@ -276,9 +276,9 @@ ORDER BY EXTRACT('year' FROM deliver_date) ASC,
 =
 SELECT *
 FROM manufacturers
-ORDER BY pg_catalog.extract('year', deliver_date) ASC
-       , pg_catalog.extract('month', deliver_date) ASC
-       , pg_catalog.extract('day', deliver_date) ASC
+ORDER BY EXTRACT(YEAR FROM deliver_date) ASC
+       , EXTRACT(MONTH FROM deliver_date) ASC
+       , EXTRACT(DAY FROM deliver_date) ASC
 
 SELECT * FROM manufacturers
 ORDER BY EXTRACT('year' FROM deliver_date) ASC,

--- a/tests/test_printers_roundtrip.py
+++ b/tests/test_printers_roundtrip.py
@@ -12,7 +12,7 @@ import sys
 
 import pytest
 
-from pglast import parse_sql, split
+from pglast import enums, parse_sql, split
 from pglast.parser import ParseError
 from pglast.stream import RawStream, IndentedStream
 import pglast.printers  # noqa
@@ -69,6 +69,45 @@ def test_printers_roundtrip(src, lineno, statement):
     # Run ``pytest -s tests/`` to see the following output
     print()
     print(indented)
+
+
+@pytest.mark.parametrize('statement,explicit_statement,bare_comma_call', (
+    (
+        "SELECT position('a' IN 'abc')",
+        "SELECT pg_catalog.position('abc', 'a')",
+        "SELECT position('abc', 'a')",
+    ),
+    (
+        "SELECT extract(year FROM now())",
+        "SELECT pg_catalog.extract('year', now())",
+        "SELECT extract('year', now())",
+    ),
+))
+@pytest.mark.parametrize('stream_class', (RawStream, IndentedStream))
+def test_special_function_sql_syntax_roundtrip_preserves_funcformat(
+        stream_class, statement, explicit_statement, bare_comma_call):
+    explicit_call = parse_sql(explicit_statement)
+    sql_syntax = parse_sql(statement)
+
+    assert explicit_call[0].stmt.targetList[0].val.funcformat == enums.CoercionForm.COERCE_EXPLICIT_CALL
+    assert sql_syntax[0].stmt.targetList[0].val.funcformat == enums.CoercionForm.COERCE_SQL_SYNTAX
+    with pytest.raises(ParseError):
+        parse_sql(bare_comma_call)
+
+    serialized = stream_class()(sql_syntax)
+    serialized_syntax = parse_sql(serialized)
+
+    assert serialized_syntax[0].stmt.targetList[0].val.funcformat == enums.CoercionForm.COERCE_SQL_SYNTAX, serialized
+
+
+@pytest.mark.parametrize('statement', (
+    "SELECT pg_catalog.extract('year', now())",
+    "SELECT pg_catalog.position('abc', 'a')",
+))
+def test_remove_pg_catalog_keeps_required_function_schema(statement):
+    serialized = RawStream(remove_pg_catalog_from_functions=True)(parse_sql(statement))
+
+    assert serialized == statement
 
 
 @pytest.mark.parametrize('src,lineno,statement',


### PR DESCRIPTION
Default parse/deparse currently changes SQL-syntax calls into explicit pg_catalog calls:

- `SELECT position('a' IN 'abc')` becomes `SELECT pg_catalog.position('abc', 'a')`
- `SELECT extract(year FROM now())` becomes `SELECT pg_catalog.extract('year', now())`

Those reparse as `COERCE_EXPLICIT_CALL` instead of preserving `COERCE_SQL_SYNTAX`.

This fixes `FuncCall` printing to use the existing special-function printers for parsed SQL-syntax `position` and `extract` calls. It also prevents `remove_pg_catalog_from_functions=True` from emitting invalid bare `extract('year', now())`.

Concrete examples:

```sql
SELECT position('a' in 'abc');      -- valid
SELECT pg_catalog.position('abc', 'a'); -- valid
SELECT position('abc', 'a');        -- syntax error at comma
```

```sql
SELECT extract(year from now());       -- valid
SELECT pg_catalog.extract('year', now()); -- valid
SELECT extract('year', now());         -- syntax error at comma
```

Other functions have special SQL syntax, but are less dangerous in this exact way because bare comma-call forms still parse:

```sql
SELECT substring('abcdef' from 2 for 3); -- special syntax
SELECT substring('abcdef', 2, 3);        -- also parses

SELECT overlay('abcdef' placing 'XX' from 2 for 3); -- special syntax
SELECT overlay('abcdef', 'XX', 2, 3);               -- also parses
```

Not sure if this is exactly how you want it fixed - let me know and i can rework it