### PR TITLE
Emit EXCLUDE frame-exclusion for single-bound window frames

### DIFF
--- a/pglast/printers/dml.py
+++ b/pglast/printers/dml.py
@@ -2265,12 +2265,12 @@ def window_def(node, output):
                     elif fo & enums.FRAMEOPTION_END_OFFSET_FOLLOWING:
                         output.print_node(node.endOffset)
                         output.swrites('FOLLOWING')
-                    if fo & enums.FRAMEOPTION_EXCLUDE_CURRENT_ROW:
-                        output.swrite('EXCLUDE CURRENT ROW')
-                    elif fo & enums.FRAMEOPTION_EXCLUDE_GROUP:
-                        output.swrite('EXCLUDE GROUP')
-                    elif fo & enums.FRAMEOPTION_EXCLUDE_TIES:
-                        output.swrite('EXCLUDE TIES')
+                if fo & enums.FRAMEOPTION_EXCLUDE_CURRENT_ROW:
+                    output.swrite('EXCLUDE CURRENT ROW')
+                elif fo & enums.FRAMEOPTION_EXCLUDE_GROUP:
+                    output.swrite('EXCLUDE GROUP')
+                elif fo & enums.FRAMEOPTION_EXCLUDE_TIES:
+                    output.swrite('EXCLUDE TIES')
 
 
 def print_indirection(node, output):

--- a/tests/test_printers_roundtrip/dml/select.sql
+++ b/tests/test_printers_roundtrip/dml/select.sql
@@ -173,6 +173,30 @@ SELECT "CustomerID",
                           RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
 FROM SalesOrderHeader
 
+SELECT CustomerID,
+       SUM(TotalDue) OVER(PARTITION BY CustomerID
+                          ORDER BY OrderDate
+                          ROWS 5 PRECEDING EXCLUDE CURRENT ROW)
+FROM SalesOrderHeader
+
+SELECT CustomerID,
+       SUM(TotalDue) OVER(PARTITION BY CustomerID
+                          ORDER BY OrderDate
+                          RANGE UNBOUNDED PRECEDING EXCLUDE GROUP)
+FROM SalesOrderHeader
+
+SELECT CustomerID,
+       SUM(TotalDue) OVER(PARTITION BY CustomerID
+                          ORDER BY OrderDate
+                          GROUPS 2 PRECEDING EXCLUDE TIES)
+FROM SalesOrderHeader
+
+SELECT CustomerID,
+       SUM(TotalDue) OVER(PARTITION BY CustomerID
+                          ORDER BY OrderDate
+                          ROWS BETWEEN 5 PRECEDING AND CURRENT ROW EXCLUDE CURRENT ROW)
+FROM SalesOrderHeader
+
 select a.id, b.value
 from sometable a join othertable b on b.id = a.id
 


### PR DESCRIPTION
`RawStream` / `IndentedStream` silently drop the `EXCLUDE CURRENT ROW` / `EXCLUDE GROUP` / `EXCLUDE TIES` frame-exclusion clause when a window frame uses a **single bound** (no `BETWEEN`), which changes the query's semantics:

```python
from pglast import parse_sql
from pglast.stream import RawStream

sql = "SELECT sum(a) OVER (ORDER BY b ROWS 5 PRECEDING EXCLUDE CURRENT ROW) FROM t"
print(RawStream()(parse_sql(sql)))
# SELECT sum(a) OVER (ORDER BY b ROWS 5 PRECEDING) FROM t      <-- EXCLUDE CURRENT ROW dropped
```

`BETWEEN` frames are unaffected (`ROWS BETWEEN 5 PRECEDING AND CURRENT ROW EXCLUDE CURRENT ROW` round-trips fine), which is the tell: the exclusion bit is in the AST, it just isn't emitted for single-bound frames.

**Root cause** (`pglast/printers/dml.py`, `window_def()`): the `EXCLUDE` printing block was nested inside the `if fo & FRAMEOPTION_BETWEEN:` branch. But in the PostgreSQL grammar `frame_exclusion` follows `frame_extent` and applies to both the single `frame_bound` and the `BETWEEN frame_bound AND frame_bound` forms. So for single-bound frames the exclusion was never printed.

**Fix**: dedent the `EXCLUDE` block one level out of the `if BETWEEN` branch so it runs for every non-default frame. `EXCLUDE NO OTHERS` (the grammar default, no bit set) still prints nothing.

**Verification** (re-runnable from the diff): added four statements to `tests/test_printers_roundtrip/dml/select.sql` — single-bound `ROWS`/`RANGE`/`GROUPS` each with a different `EXCLUDE`, plus a `BETWEEN ... EXCLUDE CURRENT ROW` guard. The round-trip harness re-parses and asserts AST equality (and also checks `IndentedStream`). The three single-bound cases fail on the current tree and pass with the fix; the full suite is green (`2120 passed` in the round-trip module).

---

*Disclosure*: This PR was authored by an AI coding agent (Claude Code) running on this account: the AI found the bug, ran the repro, wrote the tests, and wrote this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.
